### PR TITLE
Allow use of channel names with the /c command

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -668,7 +668,14 @@ export default class Display {
                 this.setActiveChannel(this.state.guild.channels.get(args[0]) as TextChannel);
             }
             else {
-                this.appendSystemMessage(`Such channel does not exist in guild '${this.state.guild.name}'`);
+                const channel = this.state.guild.channels.array().find((channel) => channel.type === "text" && (channel.name === args[0] || "#" + channel.name === args[0]));
+                
+                if (channel != null) {
+                    this.setActiveChannel(channel as TextChannel);
+                }
+                else {
+                    this.appendSystemMessage(`Such channel does not exist in guild '${this.state.guild.name}'`);
+                }
             }
         });
 

--- a/src/display.ts
+++ b/src/display.ts
@@ -668,9 +668,9 @@ export default class Display {
                 this.setActiveChannel(this.state.guild.channels.get(args[0]) as TextChannel);
             }
             else {
-                const channel = this.state.guild.channels.array().find((channel) => channel.type === "text" && (channel.name === args[0] || "#" + channel.name === args[0]));
+                const channel: TextChannel = this.state.guild.channels.array().find((channel) => channel.type === "text" && (channel.name === args[0] || "#" + channel.name === args[0])) as TextChannel;
                 
-                if (channel != null) {
+                if (channel) {
                     this.setActiveChannel(channel as TextChannel);
                 }
                 else {


### PR DESCRIPTION
Uses a simple `.find` to get a valid channel and sets it.