### PR TITLE
Actually fix ghost children bug

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -346,8 +346,14 @@ export default class App extends EventEmitter {
         }
 
         // Fixes "ghost" children bug.
-        for (let i: number = 0; i < this.options.nodes.channels.children.length; i++) {
-            this.options.nodes.channels.remove(this.options.nodes.channels.children[i]);
+        while(true){
+            try {
+              this.options.nodes.channels.remove(this.options.nodes.channels.children[0]);
+            }
+
+            catch (error) {
+              break;
+            }
         }
 
         const channels: TextChannel[] = this.state.get().guild.channels.array().filter((channel: Channel) => channel.type === "text") as TextChannel[];


### PR DESCRIPTION
When using this app I encountered "ghost" children when changing guilds:
![before](https://user-images.githubusercontent.com/61523203/75395262-1ef24c80-5946-11ea-9ddf-82c73c33ef2f.png)
![after](https://user-images.githubusercontent.com/61523203/75395303-33cee000-5946-11ea-9e5f-38cca0f0607a.png)
Around half of the other server's channels remained on the screen

With this patch the problem no longer exists
![before new](https://user-images.githubusercontent.com/61523203/75395576-cf605080-5946-11ea-92f0-6c4d488ac9fe.png)
![after new](https://user-images.githubusercontent.com/61523203/75395584-d2f3d780-5946-11ea-8271-72a461de927e.png)


